### PR TITLE
Add GPU queue/costcode selection and fix ignore_failed retry flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ nextflow run main.nf --version "0.3" --sample_table examples/sample_table_exclud
 * `--version` — Cellbender version (available: `0.2`, `0.3`; `default: 0.3`)
 * `--qc_mode` — Quality control mode (`default: 3`)
 * `--output_dir` — Output directory (`default: results`)
+* `--gpuqueue` — GPU queue to submit `CellBender` jobs to (e.g. `gpu-normal`, `cub22-inference`; `default: "gpu-normal"`). `tiger` queues are not supported; `cub` queues require `--costcode`
+* `--costcode` — Costcode to bill the job to. Only required if `--gpuqueue` is a `cub` queue
 
 ## Docker Image
 The image is based on

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ nextflow run main.nf --version "0.3" --sample_table examples/sample_table_exclud
 * `--output_dir` — Output directory (`default: results`)
 * `--gpuqueue` — GPU queue to submit `CellBender` jobs to (e.g. `gpu-normal`, `cub22-inference`; `default: "gpu-normal"`). `tiger` queues are not supported; `cub` queues require `--costcode`
 * `--costcode` — Costcode to bill the job to. Only required if `--gpuqueue` is a `cub` queue
+* `--ignore_failed` — Ignore failed `CellBender` jobs on the final retry instead of stopping the pipeline (`default: false`)
 
 ## Docker Image
 The image is based on

--- a/main.nf
+++ b/main.nf
@@ -33,6 +33,8 @@ def helpMessage() {
       --version                 Cellbender version (available: 0.2, 0.3; default: 0.3)
       --qc_mode                 Quality control mode (default: 3)
       --output_dir              Output directory (default: results)
+      --gpuqueue                GPU queue to submit cellbender jobs to (e.g. "gpu-normal", "cub22-inference"; default: "gpu-normal"). "tiger" queues are not supported; "cub" queues require --costcode
+      --costcode                Costcode to bill the job to (only required if --gpuqueue is a "cub" queue)
 
     Examples:
       # Basic usage - CellBender v0.2 with local data (manual cell/droplet counts required)
@@ -106,6 +108,17 @@ workflow {
     if (params.sample_table == null) {
       missingParametersError()
     }
+
+    // Check that costcode is provided for cub and tiger clusters
+    if (params.gpuqueue.contains("tiger")) {
+      log.error "Tiger cluster is not suited for running this pipeline. Please use cub cluster instead."
+      error "Use --gpuqueue cub22-inference --costcode <costcode> to run the pipeline on cub cluster"
+    }
+    else if (params.gpuqueue.contains("cub") && params.costcode == "") {
+      log.error "Missing costcode parameter"
+      error "Please provide a costcode using the --costcode parameter"
+    }
+
     // Puts samplefile into a channel unless it is null, if it is null then it displays error message and exits with status 1.
     sample_table = params.sample_table != null ? Channel.fromPath(params.sample_table) : missingParametersError()
     files = sample_table.splitCsv(sep: ',', header: true).map { row -> [row, row["path"]] }

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,6 +31,7 @@ params {
   mapper_preset         = false
   starsolo_mapper       = "GeneFull"
   ignore_extensions     = "bam,cram,fastq,fq,fastq.gz,fq.gz,fastq.bz2,fq.bz2,fastq.xz,fq.xz,fastq.lz4,fq.lz4,mate1.bz2,mate2.bz2"
+  ingore_failed         = false
 }
 
 // Singularity environment parameters
@@ -89,7 +90,7 @@ process {
     cpus                = { 2 * task.attempt }
     memory              = { 30.GB * task.attempt }
     queue               = 'gpu-cellgen-restricted'
-    errorStrategy       = { task.attempt < 5 ? 'retry' : 'ignore' }
+    errorStrategy       = { (task.attempt == 5) && (params.ignore_failed) ? 'ignore' : 'retry' }
     publishDir          = [
       path: { "${params.output_dir}/cellbender/" },
       mode: "${params.publish_mode}",

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,6 +15,8 @@ params {
   sample_table = null
   cells        = "" // Only for version 0.2 when .h5 file or .mtx file is provided
   droplets     = "" // Only for version 0.2 when .h5 file or .mtx file is provided
+  costcode     = "" // Only required if --gpuqueue is a "cub" queue
+  gpuqueue     = "gpu-normal"
 
   // Optional parameters
   help                  = false
@@ -85,11 +87,13 @@ process {
         params.lr                    ? "--learning-rate ${params.lr}"                                                                                                      : '',
       ].join(' ')
     }
-    clusterOptions      = ' -gpu "mode=shared:j_exclusive=no:gmem=6000:num=1"'
+    clusterOptions      = {
+      ' -gpu "mode=shared:j_exclusive=no:gmem=6000:num=1"' + (params.costcode ? " -G ${params.costcode}" : '')
+    }
     containerOptions    = '--nv'
     cpus                = { 2 * task.attempt }
     memory              = { 30.GB * task.attempt }
-    queue               = 'gpu-normal'
+    queue               = params.gpuqueue
     errorStrategy       = { (task.attempt == 5) && (params.ignore_failed) ? 'ignore' : 'retry' }
     publishDir          = [
       path: { "${params.output_dir}/cellbender/" },

--- a/nextflow.config
+++ b/nextflow.config
@@ -142,7 +142,7 @@ manifest {
   homePage        = 'https://github.com/cellgeni/nf-cellbender'
   description     = "Nextflow pipeline to run CellBender"
   mainScript      = 'main.nf'
-  nextflowVersion = '!>=25.04.4'
+  nextflowVersion = '!>=25.04.4, <25.10.0'
   version         = '26-232'
   defaultBranch   = 'main'
   contributors    = [

--- a/nextflow.config
+++ b/nextflow.config
@@ -89,7 +89,7 @@ process {
     containerOptions    = '--nv'
     cpus                = { 2 * task.attempt }
     memory              = { 30.GB * task.attempt }
-    queue               = 'gpu-cellgen-restricted'
+    queue               = 'gpu-normal'
     errorStrategy       = { (task.attempt == 5) && (params.ignore_failed) ? 'ignore' : 'retry' }
     publishDir          = [
       path: { "${params.output_dir}/cellbender/" },

--- a/nextflow.config
+++ b/nextflow.config
@@ -89,6 +89,7 @@ process {
     cpus                = { 2 * task.attempt }
     memory              = { 30.GB * task.attempt }
     queue               = 'gpu-cellgen-restricted'
+    errorStrategy       = { task.attempt < 5 ? 'retry' : 'ignore' }
     publishDir          = [
       path: { "${params.output_dir}/cellbender/" },
       mode: "${params.publish_mode}",

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,7 +33,7 @@ params {
   mapper_preset         = false
   starsolo_mapper       = "GeneFull"
   ignore_extensions     = "bam,cram,fastq,fq,fastq.gz,fq.gz,fastq.bz2,fq.bz2,fastq.xz,fq.xz,fastq.lz4,fq.lz4,mate1.bz2,mate2.bz2"
-  ingore_failed         = false
+  ignore_failed         = false
 }
 
 // Singularity environment parameters
@@ -139,11 +139,11 @@ trace {
 // Manifest
 manifest {
   name            = 'cellgeni/nf-cellbender'
-  homePage        = 'https://github.com/cellgeni/nf-irods-to-fastq'
-  description     = "Nextflow pipeline to pull .cram files from iRODS"
+  homePage        = 'https://github.com/cellgeni/nf-cellbender'
+  description     = "Nextflow pipeline to run CellBender"
   mainScript      = 'main.nf'
   nextflowVersion = '!>=25.04.4'
-  version         = '24-326'
+  version         = '26-232'
   defaultBranch   = 'main'
   contributors    = [
     [


### PR DESCRIPTION
## Summary
- Add `--gpuqueue` and `--costcode` parameters: select the LSF queue for `CELLBENDER_REMOVEBACKGROUND` (`queue = params.gpuqueue`) and bill it via `-G <costcode>` in `clusterOptions`. Rejects `tiger` queues outright and requires `--costcode` whenever `--gpuqueue` targets a `cub` queue.
- Add an `errorStrategy` override so the final retry attempt can be set to `ignore` via `--ignore_failed`, instead of always failing the pipeline on exhausted retries.
- Fix a param-name typo (`ingore_failed` → `ignore_failed`) that silently disabled the `--ignore_failed` flag, and add its missing README entry.
- Restore `manifest.homePage`/`description` to `nf-cellbender` values that had regressed to stale `nf-irods-to-fastq` text while `dev` was based on an older commit.
- Update help text (`main.nf`) and README with the new parameters.
